### PR TITLE
Settings preselect

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -215,7 +215,9 @@ const JenkinsIndicator = new Lang.Class({
 		this._menu_settings.connect("activate", function(){
 			// call gnome settings tool for this extension
 			let app = Shell.AppSystem.get_default().lookup_app("gnome-shell-extension-prefs.desktop");
-			if( app!=null ) app.activate();
+			if( app!=null ) {
+				app.launch(global.display.get_current_time_roundtrip(), ['extension:///' + Me.uuid], -1, null);
+      			}
 		});
 		this.menu.addMenuItem(this._menu_settings);
         


### PR DESCRIPTION
clicking settings will select the extension when opened from "panel". 
ps: Is the manual install instruction in readme working for you?
I had to rename the folder to uuid (jenkins-indicator@philipphoffmann.de) not 'gnome3-jenkins@philipphoffmann.de'
