### PR TITLE
Adding scrollbars to config panels

### DIFF
--- a/prefs.js
+++ b/prefs.js
@@ -50,7 +50,7 @@ function addTabPanel(notebook, server_num)
     // use server name as tab label
     let tabLabel = new Gtk.Label({ label: settingsJSON['servers'][server_num]['name']});
     
-    let vbox = new Gtk.Box({ orientation: Gtk.Orientation.VERTICAL });
+    let vbox = new Gtk.Box({ orientation: Gtk.Orientation.VERTICAL, border_width: 10 });
 
     // *** jenkins connection ***
     let labelJenkinsConnection = new Gtk.Label({ label: "<b>" + _("Jenkins connection") + "</b>", use_markup: true, xalign: 0 });
@@ -264,8 +264,8 @@ function addTabPanel(notebook, server_num)
     tabWidget.show_all();
     
     // tab content
-    let tabContent = new Gtk.Box({ orientation: Gtk.Orientation.VERTICAL, border_width: 10 });
-    tabContent.add(vbox);
+    let tabContent = new Gtk.ScrolledWindow({ vexpand: true });
+    tabContent.add_with_viewport(vbox);
     
     // append tab to notebook
     notebook.append_page(tabContent, tabWidget);


### PR DESCRIPTION
The config options are too long to fit on 1366x768px and below resolutions.

This commit adds an _(at moment)_ vertical scrollbar to the options list.
So, we can now happly scroll through each setting.

![before](https://f.cloud.github.com/assets/320460/54597/285ba814-5a9a-11e2-80e4-38b477201d46.png)

![after](https://f.cloud.github.com/assets/320460/54599/2fa11528-5a9a-11e2-911f-a6f1d5ac60aa.png)
