### PR TITLE
now showing blue/green status indicator when there are no jobs but we filtered out successful jobs

### DIFF
--- a/src/helpers/utils.js
+++ b/src/helpers/utils.js
@@ -91,7 +91,7 @@ function jobMatches(job, patterns) {
 		// early exit check
 		if (!passedFilters) {
 			// breaking loop early, since no need to do pattern matching further
-			log_info('Not matching job ' + job.name + ' further');
+			//log_info('Not matching job ' + job.name + ' further');
 			return;
 		}
 		var positiveSearch = pattern.indexOf("!") !== 0;
@@ -104,12 +104,12 @@ function jobMatches(job, patterns) {
 		if (positiveSearch) {
 			passedFilters = passedFilters && matchingPattern;
 			if (passedFilters) {
-				log_info('Positive match for job ' + job.name + ' for pattern [' + pattern + ']');
+				//log_info('Positive match for job ' + job.name + ' for pattern [' + pattern + ']');
 			}
 		} else {
 			passedFilters = passedFilters && !matchingPattern;
 			if (passedFilters) {
-				log_info('Negative match for job ' + job.name + ' for pattern [' + pattern + ']');
+				//log_info('Negative match for job ' + job.name + ' for pattern [' + pattern + ']');
 			}
 		}
 	})

--- a/src/jenkinsIndicator.js
+++ b/src/jenkinsIndicator.js
@@ -86,7 +86,7 @@ const JenkinsIndicator = new Lang.Class({
 				this.httpSession.queue_message(request, Lang.bind(this, function(httpSession, message) {
 					// http error
 					if( message.status_code!==200 )	{
-						this.showError(_("Invalid Jenkins CI Server web frontend URL (HTTP Error %s)").format(message.status_code));
+						this.showError(_("(%s) Invalid Jenkins CI Server web frontend URL").format(message.status_code));
 					}
 					// http ok
 					else {
@@ -102,7 +102,7 @@ const JenkinsIndicator = new Lang.Class({
 						}
 						catch( e ) {
 							global.log(e)
-							this.showError(_("Invalid Jenkins CI Server web frontend URL"));
+							this.showError(_("Empty or invalid response from server"));
 						}
 					}
 
@@ -126,8 +126,8 @@ const JenkinsIndicator = new Lang.Class({
 		let displayJobs = Utils.filterJobs(this.jobs, this.settings);
 
         if (displayJobs.length == 0) {
-            this.showMessage("No jobs found", {style_class: 'warning'});
-            
+            this.menu.showMessage("No jobs found", {style_class: 'warning'});
+
             if (!this.settings.show_successful_jobs) {
                 // assuming we filtered out "successful" jobs
                 this._iconActor.icon_name = Utils.jobStates.getIcon("blue", this.settings.green_balls_plugin);
@@ -136,8 +136,11 @@ const JenkinsIndicator = new Lang.Class({
         }
 
         // update popup menu
-        this.menu.updateJobs(displayJobs);
-    
+				// remove all job menu entries and previous error messages
+				this.menu.clear();
+				this.menu.populate(displayJobs);
+				//this.menu.updateJobs(displayJobs);
+
         // update overall indicator icon
 
         // default state of overall indicator
@@ -180,19 +183,11 @@ const JenkinsIndicator = new Lang.Class({
 		// set default error message if none provided
 		text = text || "unknown error";
 
-        this.showMessage(_("Error") + ": " + text, {style_class: 'error'});
-        
+        this.menu.showMessage(_("Error") + ": " + text, {style_class: 'error'});
+
 		// set indicator state to error
 		this._iconActor.icon_name = Utils.jobStates.getIcon(Utils.jobStates.getErrorState(), this.settings.green_balls_plugin);
 	},
-    
-    showMessage: function(text, style) {
-		// remove all job menu entries and previous error messages
-		this.menu.jobSection.removeAll();
-
-		// show error message in popup menu
-		this.menu.jobSection.addMenuItem( new PopupMenu.PopupMenuItem(text, style) );
-    },
 
 	// destroys the indicator
 	destroy: function() {

--- a/src/serverPopupMenu.js
+++ b/src/serverPopupMenu.js
@@ -27,7 +27,7 @@ const ServerPopupMenu = new Lang.Class({
 
 	_init: function(indicator, sourceActor, arrowAlignment, arrowSide, notification_source, settings, httpSession) {
 		this.parent(sourceActor, arrowAlignment, arrowSide);
-		
+
 		this.indicator = indicator;
 		this.notification_source = notification_source;
 		this.settings = settings;
@@ -68,6 +68,34 @@ const ServerPopupMenu = new Lang.Class({
 		this.addMenuItem(this._menu_settings);
 	},
 
+	//
+  showMessage: function(text, style) {
+		// remove all job menu entries and previous error messages
+		clear();
+
+		// show error message in popup menu
+		this.jobSection.addMenuItem( new PopupMenu.PopupMenuItem(text, style) );
+  },
+
+	// remove any message, if present
+	clear: function() {
+		// remove message
+		if( this.jobSection.firstMenuItem && this.jobSection.firstMenuItem instanceof PopupMenu.PopupMenuItem ) {
+			this.jobSection.firstMenuItem.destroy();
+		}
+
+		// remove all job menu entries
+		this.jobSection.removeAll();
+	},
+
+  // append all given job items in popup menu
+	populate: function(jobs) {
+		// check all new job items
+		for( let i=0 ; i<jobs.length ; ++i ) {
+				this.jobSection.addMenuItem( new JobPopupMenuItem.JobPopupMenuItem(this, jobs[i], this.notification_source, this.settings, this.httpSession) );
+		}
+	},
+
 	// insert, delete and update all job items in popup menu
 	updateJobs: function(new_jobs) {
 		// provide error message if no jobs were found
@@ -75,11 +103,8 @@ const ServerPopupMenu = new Lang.Class({
 			this.indicator.showError(_("No jobs found"));
 			return;
 		}
-		
-		// remove previous error message
-		if( this.jobSection.firstMenuItem && this.jobSection.firstMenuItem instanceof PopupMenu.PopupMenuItem ) {
-			this.jobSection.firstMenuItem.destroy();
-		}
+
+		clear();
 
 		// check all new job items
 		for( let i=0 ; i<new_jobs.length ; ++i ) {
@@ -103,7 +128,7 @@ const ServerPopupMenu = new Lang.Class({
 				this.jobSection.addMenuItem( new JobPopupMenuItem.JobPopupMenuItem(this, new_jobs[i], this.notification_source, this.settings, this.httpSession) );
 			}
 		}
-		
+
 		// check for jobs that need to be removed
 		for( let j = 0 ; j<this.jobSection.numMenuItems ; ++j ) {
 			let job_found = false;
@@ -121,13 +146,13 @@ const ServerPopupMenu = new Lang.Class({
 			}
 		}
 	},
-	
+
 	// update settings
 	updateSettings: function(settings) {
 		this.settings = settings;
 
 		this.serverMenuItem.updateSettings(this.settings);
-		
+
 		// push new settings to job menu items
 		for( let j = 0 ; j<this.jobSection.numMenuItems ; ++j )	{
 			if( this.jobSection._getMenuItems()[j] instanceof JobPopupMenuItem.JobPopupMenuItem ) {

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -32,3 +32,8 @@
 	color: #ff0000;
 	font-weight: bold;
 }
+
+.warning {
+    color: #ffff00;
+    font-weight: bold;
+}


### PR DESCRIPTION
Since this extension is pretty slow and it tends to freeze the gnome-shell when there are many jobs, some users (like me) needs to filter-out successful-jobs to get an usable interface.
In these cases, when there are no jobs the extensions shows an error while the correct indication should be "everything is building correctly".

I changed this behavior by checking for the show_successful_jobs when no jobs are found.
The message "no jobs found" is still being shown but as warning instead as an error so that the user may still check for its filters if the result does not match with the expected.